### PR TITLE
Remove runtime PlexAPI install

### DIFF
--- a/Plex_Trailers.py
+++ b/Plex_Trailers.py
@@ -1,29 +1,18 @@
 #!/usr/bin/python
-import subprocess
-import sys
+"""Update Plex preroll trailers based on the current month."""
+
 try:
     from plexapi.server import PlexServer
-
-except:
-    print('\033[91mERROR:\033[0m PlexAPI is not installed.')
-    x = input("Do you want to install it? y/n:")
-    if x == 'y':
-        subprocess.check_call([sys.executable, "-m", "pip", "install", 'PlexAPI==4.2.0'])
-        from plexapi.server import PlexServer
-    elif x == 'n':
-        sys.exit()
+except ImportError as exc:
+    raise ImportError(
+        "PlexAPI is required. Install dependencies with 'pip install -r requirements.txt'."
+    ) from exc
 
 import requests
-from urllib.parse import quote_plus, urlencode
 from datetime import datetime
-
-from plexapi import media, utils, settings, library
-from plexapi.base import Playable, PlexPartialObject
-from plexapi.exceptions import BadRequest, NotFound
 
 from argparse import ArgumentParser
 import os
-import random
 import pathlib
 from configparser import *
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ https://github.com/TheHumanRobot/Automatic-Pre-roll-GUI
 Automated script to change out plex preroll every month
 
 ## Requirements
--[Python 3.7+](https://www.python.org/)
-(Probably works on a lower version haven't tested)
-
--[PlexAPI](https://github.com/pkkid/python-plexapi)
+* [Python 3.7+](https://www.python.org/) (probably works on a lower version, but it hasn't been tested)
+* [PlexAPI](https://github.com/pkkid/python-plexapi)
 
 
 
@@ -19,7 +17,9 @@ First make sure you have Python installed version 3.7 and above. Next run:
 ```
 pip install -r requirements.txt
 ```
-That will install all the needed packages 
+That will install all the needed packages, including PlexAPI. If you run the
+script without installing these requirements, it will exit with an ImportError
+prompting you to install them.
 
 ## Step by step instructions by Danny at smarthomepursuits.com
 


### PR DESCRIPTION
## Summary
- clean up unused imports in Plex_Trailers
- remove runtime PlexAPI installation and raise a clear error instead
- refresh README requirements and installation details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cbdc5d5ec8332ae3681ddb70ae100